### PR TITLE
Bump dep version to support GHC 8.8

### DIFF
--- a/hyraxAbif.cabal
+++ b/hyraxAbif.cabal
@@ -44,10 +44,10 @@ library
                      , Examples.ReadAb1
   build-depends:       base >= 4.9.1.0 && < 5
                      , protolude >= 0.2.2 && < 0.2.5
-                     , text >= 1.2.3.0 && < 1.2.4.0
-                     , bytestring >= 0.10.8.2 && < 0.10.9.0
-                     , binary >= 0.8.5.1 && < 0.8.7.0
-                     , directory >= 1.3.0.2 && < 1.3.4.0
+                     , text >= 1.2.3.0 && < 1.2.5.0
+                     , bytestring >= 0.10.8.2 && < 0.10.11.0
+                     , binary >= 0.8.5.1 && < 0.8.8.0
+                     , directory >= 1.3.0.2 && < 1.3.5.0
                      , filepath >= 1.4.1.2 && < 1.4.3.0
   default-language:    Haskell2010
 
@@ -58,8 +58,8 @@ executable hyraxAbif-exe
   build-depends:       base >= 4.9.1.0 && < 5
                      , hyraxAbif
                      , protolude >= 0.2.2 && < 0.2.5
-                     , text >= 1.2.3.0 && < 1.2.4.0
-                     , bytestring >= 0.10.8.2 && < 0.10.9.0
+                     , text >= 1.2.3.0 && < 1.2.5.0
+                     , bytestring >= 0.10.8.2 && < 0.10.11.0
                      , pretty-show >= 1.6.16 && < 1.10.0
                      , hscolour >= 1.24.4 && < 1.25.0
   default-language:    Haskell2010
@@ -71,9 +71,9 @@ test-suite hyraxAbif-test
   build-depends:       base >= 4.9.1.0 && < 5
                      , hyraxAbif
                      , protolude >= 0.2.2 && < 0.2.5
-                     , text >= 1.2.3.0 && < 1.2.4.0
-                     , bytestring >= 0.10.8.2 && < 0.10.9.0
-                     , binary >= 0.8.5.1 && < 0.8.7.0
+                     , text >= 1.2.3.0 && < 1.2.5.0
+                     , bytestring >= 0.10.8.2 && < 0.10.11.0
+                     , binary >= 0.8.5.1 && < 0.8.8.0
                      , hedgehog >= 0.5.3 && < 1.1.0
   other-modules:       AbifTests
                      , FastaTests


### PR DESCRIPTION
Hi,

stackage already builds nightly snapshots with GHC 8.8 and currently hyraxAbif can't be built with them due to too restrictive version constraints in cabal file.

This PR updates those constraints. I've built and run test suite on `nightly-2020-02-04`.