### PR TITLE
Update version bounds for GHC-9.2

### DIFF
--- a/hyraxAbif.cabal
+++ b/hyraxAbif.cabal
@@ -45,12 +45,12 @@ library
   build-depends:       base >= 4.9.1.0 && < 5
                      , protolude           >= 0.3.0 && < 0.4
                      , binary              >= 0.8.8 && < 0.9
-                     , bytestring          >= 0.10.12 && < 0.11
+                     , bytestring          >= 0.10.12 && < 0.12
                      , directory           >= 1.3.6 && < 1.4
                      , filepath            >= 1.4.2 && < 1.5
                      , hscolour            >= 1.24.4 && < 1.25
                      , pretty-show         >= 1.10 && < 1.11
-                     , text                >= 1.2.4 && < 1.3
+                     , text                >= 1.2.4 && < 2.1
   default-language:    Haskell2010
 
 executable hyraxAbif-exe
@@ -60,8 +60,8 @@ executable hyraxAbif-exe
   build-depends:       base >= 4.9.1.0 && < 5
                      , hyraxAbif
                      , protolude           >= 0.3.0 && < 0.4
-                     , text                >= 1.2.4 && < 1.3
-                     , bytestring          >= 0.10.12 && < 0.11
+                     , text                >= 1.2.4 && < 2.1
+                     , bytestring          >= 0.10.12 && < 0.12
                      , pretty-show         >= 1.10 && < 1.11
                      , hscolour            >= 1.24.4 && < 1.25
   default-language:    Haskell2010
@@ -73,10 +73,10 @@ test-suite hyraxAbif-test
   build-depends:       base >= 4.9.1.0 && < 5
                      , hyraxAbif
                      , protolude           >= 0.3.0 && < 0.4
-                     , text                >= 1.2.4 && < 1.3
-                     , bytestring          >= 0.10.12 && < 0.11
+                     , text                >= 1.2.4 && < 2.1
+                     , bytestring          >= 0.10.12 && < 0.12
                      , binary              >= 0.8.8 && < 0.9
-                     , hedgehog            >= 1.0.5 && < 1.1
+                     , hedgehog            >= 1.0.5 && < 1.2
   other-modules:       AbifTests
                      , FastaTests
                      , Generators


### PR DESCRIPTION
I've tested this locally with stackage `nightly-2022-03-23` and protolude from git (not yet released to Hackage), it builds fine and tests pass.

So I think you can just merge this and update Cabal file on Hackage, to allow new bounds.